### PR TITLE
Add Bootstrap user registration page (new-regis.php)

### DIFF
--- a/new-regis.php
+++ b/new-regis.php
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ลงทะเบียนผู้ใช้</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+</head>
+<body class="bg-light">
+  <div class="container py-5">
+    <div class="row justify-content-center">
+      <div class="col-12 col-sm-10 col-md-8 col-lg-6">
+        <div class="card shadow-sm">
+          <div class="card-body p-4">
+            <h1 class="h4 text-center mb-4">ลงทะเบียนผู้ใช้</h1>
+            <form>
+              <div class="mb-3">
+                <label for="email" class="form-label">อีเมล์</label>
+                <input type="email" class="form-control" id="email" name="email" placeholder="name@example.com" required>
+              </div>
+              <div class="mb-3">
+                <label for="password" class="form-label">รหัสผ่าน</label>
+                <input type="password" class="form-control" id="password" name="password" placeholder="กรอกรหัสผ่าน" required>
+              </div>
+              <div class="d-grid">
+                <button type="submit" class="btn btn-primary">ลงทะเบียน</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Implement a user registration page with email and password fields using Bootstrap saved as `new-regis.php`.
- Provide a responsive, styled front-end form as the initial step toward a registration system.
- Present the UI in Thai to match the project's localization.

### Description
- Added new file `new-regis.php` containing a Bootstrap-styled registration form with `email` and `password` inputs.
- Included Bootstrap CSS and JS via CDN and placed the form inside a responsive card layout.
- The form is client-side only and currently has no `action` attribute or server-side processing attached.

### Testing
- No automated tests were run for this static page change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f2abfcedc832fa4b94931c787c849)